### PR TITLE
fix: use flexera one credentials for plugin auth

### DIFF
--- a/aws/rs_aws_compute/changelog.md
+++ b/aws/rs_aws_compute/changelog.md
@@ -3,6 +3,7 @@
 ## v3.0.0
 
 - Support for credential service
+- Updated Compute Test CAT to use credential service
 
 ## v2.1.1
 

--- a/aws/rs_aws_compute/compute_instance_test_cat.rb
+++ b/aws/rs_aws_compute/compute_instance_test_cat.rb
@@ -14,6 +14,7 @@ parameter "param_instance_count" do
   default 2
 end
 
+# Credential for plugin must be named `auth_aws` to match credential name in plugin
 credentials "auth_aws" do
   schemes "aws","aws_sts"
   label "AWS"
@@ -56,7 +57,7 @@ operation "terminate" do
   definition "generated_terminate"
 end
 
-define generated_launch($param_region, @instances, $auth_aws) return @instances do
+define generated_launch($param_region, @instances) return @instances do
   provision(@instances)
 end
 

--- a/azure/rs_azure_compute/changelog.md
+++ b/azure/rs_azure_compute/changelog.md
@@ -3,6 +3,7 @@
 ## v3.0.0
 
 - Support for credential service
+- Updated Compute Test CAT to use credential service
 
 ## v2.0.1 (08-23-2021)
 

--- a/azure/rs_azure_compute/compute_test_cat.rb
+++ b/azure/rs_azure_compute/compute_test_cat.rb
@@ -6,6 +6,7 @@ import "azure/cloud_parameters"
 import "plugins/azure_compute"
 import "plugins/rs_azure_networking"
 
+# Credential for plugin must be named `azure_auth` to match credential name in plugin
 credentials "azure_auth" do
   schemes "oauth2"
   label "Azure"
@@ -132,7 +133,7 @@ operation "change_size" do
   definition "supersize_me"
 end
 
-define launch_handler($tenant_id, $subscription_id, @azure_nic, @server1, @my_vm_extension, $azure_auth) return @server1,@my_vm_extension,$vms,$vmss do
+define launch_handler($tenant_id, $subscription_id, @azure_nic, @server1, @my_vm_extension) return @server1,@my_vm_extension,$vms,$vmss do
   call start_debugging()
   provision(@azure_nic)
   provision(@server1)
@@ -155,7 +156,7 @@ define getSizes() return $values do
   end
 end
 
-define supersize_me(@server1, $vmSize, $azure_auth) return @server1 do
+define supersize_me(@server1, $vmSize) return @server1 do
   @vm=rs_azure_compute.virtualmachine.show(resource_group: @@deployment.name, virtualMachineName: @server1.name)
   $vm_object=to_object(@vm)
   $vm_fields=$vm_object["details"][0]

--- a/azure/rs_azure_compute/compute_test_cat.rb
+++ b/azure/rs_azure_compute/compute_test_cat.rb
@@ -6,6 +6,13 @@ import "azure/cloud_parameters"
 import "plugins/azure_compute"
 import "plugins/rs_azure_networking"
 
+credentials "azure_auth" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
 parameter "tenant_id" do
   like $cloud_parameters.tenant_id
 end
@@ -125,7 +132,7 @@ operation "change_size" do
   definition "supersize_me"
 end
 
-define launch_handler($tenant_id, $subscription_id, @azure_nic, @server1, @my_vm_extension) return @server1,@my_vm_extension,$vms,$vmss do
+define launch_handler($tenant_id, $subscription_id, @azure_nic, @server1, @my_vm_extension, $azure_auth) return @server1,@my_vm_extension,$vms,$vmss do
   call start_debugging()
   provision(@azure_nic)
   provision(@server1)
@@ -148,7 +155,7 @@ define getSizes() return $values do
   end
 end
 
-define supersize_me(@server1,$vmSize) return @server1 do
+define supersize_me(@server1, $vmSize, $azure_auth) return @server1 do
   @vm=rs_azure_compute.virtualmachine.show(resource_group: @@deployment.name, virtualMachineName: @server1.name)
   $vm_object=to_object(@vm)
   $vm_fields=$vm_object["details"][0]


### PR DESCRIPTION
### Description
Fixes issue with Azure Compute Test CAT which now requires using Flexera One Credentials
